### PR TITLE
턴타이머, 점수 중복적용, 승패판정 수정

### DIFF
--- a/Assets/02_Scripts/Common/GameManager.cs
+++ b/Assets/02_Scripts/Common/GameManager.cs
@@ -216,9 +216,16 @@ public class GameManager : Singleton<GameManager>
         while (timer > 0f)
         {
             timer -= Time.deltaTime;
+
+            // 씬 전환되면 바로 멈추도록 체크 후 브레이크
+            if (_gameUIController == null || !_gameUIController.isActiveAndEnabled)
+                yield break;
+
             _gameUIController.UpdateTimerUI(timer, playerType);
             yield return null;
         }
+
+        if (_gameUIController == null) yield break;
 
         OpenConfirmPanel("타임 오버", () =>
         {
@@ -227,6 +234,8 @@ public class GameManager : Singleton<GameManager>
 
         ToggleGame(false);
     }
+
+
     public void ToggleGame(bool active)
     {
         _blockController.gameObject.SetActive(active);
@@ -257,16 +266,24 @@ public class GameManager : Singleton<GameManager>
         if (isGameOver) return;
         isGameOver = true;
 
-        // 멀티 모드일 때만 서버에 결과 보고
         if (_gameType == Constants.GameType.MultiPlay)
         {
-            string myEmail = UserData.Instance.Email;
-            string opponentEmail = UserData.Instance.OpponentEmail;
-
-            StartCoroutine(ReportGameResult(myEmail, opponentEmail, isWin, () =>
+            // 흑돌(방장)만 서버에 결과 보고
+            if (UserData.Instance.IsBlack)
             {
-                UserData.Instance.ClearOpponent(); // 게임이 끝나면 상대 데이터 초기화
-            }));
+                string myEmail = UserData.Instance.Email;
+                string opponentEmail = UserData.Instance.OpponentEmail;
+
+                StartCoroutine(ReportGameResult(myEmail, opponentEmail, isWin, () =>
+                {
+                    UserData.Instance.ClearOpponent();
+                }));
+            }
+            else
+            {
+                Debug.Log("백 플레이어는 결과 보고 안 함 → UI만 닫음");
+                UserData.Instance.ClearOpponent();
+            }
         }
         else
         {

--- a/Assets/02_Scripts/JHY/Game/GameLogic.cs
+++ b/Assets/02_Scripts/JHY/Game/GameLogic.cs
@@ -1,4 +1,3 @@
-
 using static Constants;
 using System;
 using UnityEngine;
@@ -6,7 +5,6 @@ using UnityEngine;
 public class GameLogic : IDisposable
 {
     public BlockController blockController;
-
 
     public BasePlayerState firstPlayerState;
     public BasePlayerState secondPlayerState;
@@ -17,16 +15,11 @@ public class GameLogic : IDisposable
 
     public BasePlayerState CurrentPlayerState { get; set; }
 
-    // Multi
-    //private MultiplayController _multiplayController;
-    //private string _roomId;
-
     public GameLogic(BlockController blockController, GameType gameType)
     {
         this.blockController = blockController;
 
         _board = new PlayerType[BlockColumnCount, BlockColumnCount];
-
         currnetPlayMode = gameType;
 
         // 블록 클릭 → 커서만 표시
@@ -41,9 +34,7 @@ public class GameLogic : IDisposable
         switch (gameType)
         {
             case GameType.SinglePlay:
-                // 선공(흑돌)
                 firstPlayerState = new PlayerState(true);
-                // 후공(백돌)
                 secondPlayerState = new AIState(false);
                 SetState(firstPlayerState);
                 break;
@@ -52,30 +43,10 @@ public class GameLogic : IDisposable
                 secondPlayerState = new PlayerState(false);
                 SetState(firstPlayerState);
                 break;
-            case Constants.GameType.MultiPlay:
+            case GameType.MultiPlay:
                 InitMultiPlay();
                 break;
         }
-    }
-
-    private void InitSinglePlay()
-    {
-        Debug.Log("싱글플레이 시작");
-        firstPlayerState = new PlayerState(true);
-        secondPlayerState = new AIState(false);
-
-        SetState(firstPlayerState);
-        GameManager.Instance.StartTurn(Constants.PlayerType.PlayerA);
-    }
-
-    private void InitDualPlay()
-    {
-        Debug.Log("듀얼플레이 시작");
-        firstPlayerState = new PlayerState(true);
-        secondPlayerState = new PlayerState(false);
-
-        SetState(firstPlayerState);
-        GameManager.Instance.StartTurn(Constants.PlayerType.PlayerA);
     }
 
     private void InitMultiPlay()
@@ -95,19 +66,15 @@ public class GameLogic : IDisposable
             secondPlayerState = new MultiplayerState(false, MatchingManager.Instance.CurrentRoomId);
             SetState(firstPlayerState);
 
-            // 시작 시 내 턴임을 명확히 지정
             (firstPlayerState as MultiplayerState)?.SetTurn(true);
-
             GameManager.Instance.StartTurn(Constants.PlayerType.PlayerA);
         }
         else
         {
-            // 백: 후수 플레이어
             firstPlayerState = new MultiplayerState(false, MatchingManager.Instance.CurrentRoomId);
             secondPlayerState = new MultiplayerState(true, MatchingManager.Instance.CurrentRoomId);
-            SetState(firstPlayerState); // 현재는 흑 차례
+            SetState(firstPlayerState);
 
-            // 바로 "상대방 턴" UI와 타이머 시작
             GameManager.Instance.StartTurn(Constants.PlayerType.PlayerA);
         }
 
@@ -134,26 +101,20 @@ public class GameLogic : IDisposable
 
     public void SelectBlock(int row, int col)
     {
-        // 이미 놓여진 경우
-        if (_board[row, col] != PlayerType.None)
-            return;
+        if (_board[row, col] != PlayerType.None) return;
 
         Block.MarkerType markerType = Block.MarkerType.None;
 
         if (CurrentPlayerState is PlayerState playerState)
         {
-            // 싱글/듀얼일 때
             markerType = (playerState.PlayerType == PlayerType.PlayerA)
-                ? Block.MarkerType.Black
-                : Block.MarkerType.White;
+                ? Block.MarkerType.Black : Block.MarkerType.White;
         }
         else if (CurrentPlayerState is MultiplayerState)
         {
-            // 멀티일 때
             var currentTurn = GetCurrentPlayerType();
             markerType = (currentTurn == Constants.PlayerType.PlayerA)
-                ? Block.MarkerType.Black
-                : Block.MarkerType.White;
+                ? Block.MarkerType.Black : Block.MarkerType.White;
         }
         else
         {
@@ -161,13 +122,7 @@ public class GameLogic : IDisposable
             return;
         }
 
-        if (blockController == null)
-        {
-            Debug.LogError("blockController가 초기화되지 않았습니다.");
-            return;
-        }
-
-        blockController.PlaceScope(markerType, row, col);
+        blockController?.PlaceScope(markerType, row, col);
     }
 
     public void ConfirmPlay()
@@ -176,8 +131,7 @@ public class GameLogic : IDisposable
 
         if (row != -1 && col != -1)
         {
-            Debug.Log("실행");
-            if(CurrentPlayerState == firstPlayerState)
+            if (CurrentPlayerState == firstPlayerState)
                 CurrentPlayerState.HandleMove(this, PlayerType.PlayerA, row, col);
             else
                 CurrentPlayerState.HandleMove(this, PlayerType.PlayerB, row, col);
@@ -186,13 +140,11 @@ public class GameLogic : IDisposable
 
     public bool SetNewBoardValue(PlayerType playerType, int row, int col)
     {
-        // 이미 보드에 돌을 놓은 플레이어가 존재한다면
         if (_board[row, col] != PlayerType.None)
             return false;
 
         _board[row, col] = playerType;
 
-        // 싱글/듀얼만 타이머 리셋
         if (GameManager._gameType != Constants.GameType.MultiPlay)
             GameManager.Instance.TimerReset(playerType);
 
@@ -216,7 +168,37 @@ public class GameLogic : IDisposable
         });
     }
 
-    public GameResult CheckGameResult() => GameResult.None;
+    // 승리/무승부 판정
+    public GameResult CheckGameResult((int row, int col) lastMove)
+    {
+        var winner = GameResultChecker.CheckBoardState(_board, lastMove);
+
+        if (winner == PlayerType.PlayerA)
+        {
+            return UserData.Instance.IsBlack ? GameResult.Win : GameResult.Lose;
+        }
+        else if (winner == PlayerType.PlayerB)
+        {
+            return UserData.Instance.IsBlack ? GameResult.Lose : GameResult.Win;
+        }
+        else if (GameResultChecker.CheckGameDraw(_board))
+        {
+            return GameResult.Draw;
+        }
+        else
+        {
+            return GameResult.None;
+        }
+    }
+
+    // 기존 코드가 부르는 매개변수 없는 버전 → 내부에서 FocusBlock 좌표 쓰기
+    public GameResult CheckGameResult()
+    {
+        var (row, col) = blockController.GetFocusBlockPosition();
+        if (row == -1 || col == -1) return GameResult.None;
+
+        return CheckGameResult((row, col));
+    }
 
     public void Dispose() { }
 }

--- a/Assets/02_Scripts/SW/Network/MultiplayController.cs
+++ b/Assets/02_Scripts/SW/Network/MultiplayController.cs
@@ -72,37 +72,18 @@ public class MultiplayController : IDisposable
                     var data = array[0];
                     RoomId = data["roomId"]?.Value<string>();
 
-                    var players = data["players"]?.ToObject<string[]>();
-                    Debug.Log($"서버 이벤트: startGame, roomId={RoomId}, players={string.Join(",", players)}");
+                    string black = data["black"]?.ToString();
+                    string white = data["white"]?.ToString();
 
-                    if (players != null && players.Length == 2)
-                    {
-                        string myEmail = UserData.Instance.Email;
-                        string opponentEmail = (players[0] == myEmail) ? players[1] : players[0];
-                        UserData.Instance.OpponentEmail = opponentEmail;
+                    Debug.Log($"서버 이벤트: startGame, roomId={RoomId}, black={black}, white={white}");
 
-                        Debug.Log($"[startGame] myEmail={myEmail}, players={string.Join(",", players)}");
-                        Debug.Log($"[startGame] opponentEmail={opponentEmail}");
+                    string myEmail = UserData.Instance.Email;
+                    string opponentEmail = (myEmail == black) ? white : black;
+                    UserData.Instance.OpponentEmail = opponentEmail;
 
-                        MatchingManager.Instance.EnqueueOnMainThread(() =>
-                        {
-                            MatchingManager.Instance.StartCoroutine(
-                                UserData.Instance.RefreshOpponentData(() =>
-                                {
-                                    if (UserData.Instance.Rank > UserData.Instance.OpponentRank)
-                                    {
-                                        UserData.Instance.IsBlack = true;
-                                        Debug.Log("내 급수 숫자가 더 높음 → 내가 흑돌");
-                                    }
-                                    else
-                                    {
-                                        UserData.Instance.IsBlack = false;
-                                        Debug.Log("상대 급수 숫자가 더 높음 → 내가 백돌");
-                                    }
-                                })
-                            );
-                        });
-                    }
+                    // 서버가 지정한 흑/백 정보 반영
+                    UserData.Instance.IsBlack = (myEmail == black);
+                    Debug.Log($"내 이메일={myEmail}, 흑={black}, 백={white}, → 나는 {(UserData.Instance.IsBlack ? "흑" : "백")}");
 
                     MatchingManager.Instance.EnqueueOnMainThread(() =>
                     {

--- a/Assets/02_Scripts/SW/User/MultiplayerState.cs
+++ b/Assets/02_Scripts/SW/User/MultiplayerState.cs
@@ -20,14 +20,6 @@ public class MultiplayerState : BasePlayerState
 
     public override void OnEnter(GameLogic gameLogic)
     {
-        Debug.Log("멀티플레이 상태 진입 isMyTurn=" + isMyTurn);
-
-        // 내 턴이라면 확실히 true로 초기화
-        if (isMyTurn)
-        {
-            SetTurn(true);
-        }
-
         var controller = MatchingManager.Instance?.GetMultiplayController();
         if (controller != null)
         {
@@ -44,23 +36,29 @@ public class MultiplayerState : BasePlayerState
                 if (gameLogic.SetNewBoardValue(opponentType, row, col))
                 {
                     var markerType = opponentType == Constants.PlayerType.PlayerA
-                        ? Block.MarkerType.Black
-                        : Block.MarkerType.White;
+                        ? Block.MarkerType.Black : Block.MarkerType.White;
 
                     gameLogic.blockController.PlaceStone(markerType, row, col);
 
-                    // 상대가 두면 → 내 턴으로 전환
+                    // ✅ 상대방 수 → 승리 체크
+                    var result = gameLogic.CheckGameResult((row, col));
+                    if (result != GameLogic.GameResult.None)
+                    {
+                        bool iWin = (result == GameLogic.GameResult.Win);
+                        gameLogic.EndGame(result);
+                        GameManager.Instance.EndGame(iWin);
+                        return;
+                    }
+
+                    // 내 턴으로 전환
                     var myType = UserData.Instance.IsBlack
                         ? Constants.PlayerType.PlayerA
                         : Constants.PlayerType.PlayerB;
 
                     gameLogic.SetState(
                         myType == Constants.PlayerType.PlayerA
-                            ? gameLogic.firstPlayerState
-                            : gameLogic.secondPlayerState
-                    );
+                            ? gameLogic.firstPlayerState : gameLogic.secondPlayerState);
 
-                    // 내 턴 여부 동기화
                     if (gameLogic.CurrentPlayerState is MultiplayerState multi)
                     {
                         bool myTurnNow =
@@ -76,24 +74,14 @@ public class MultiplayerState : BasePlayerState
 
         gameLogic.blockController.OnBlockClickedDelegate = (row, col) =>
         {
-            if (isMyTurn)
-            {
-                Debug.Log($"내 턴 → 블록 클릭 row={row}, col={col}");
-                gameLogic.SelectBlock(row, col);
-            }
-            else
-            {
-                Debug.Log("내 턴이 아님 → 클릭 무시");
-            }
+            if (isMyTurn) gameLogic.SelectBlock(row, col);
+            else Debug.Log("내 턴이 아님 → 클릭 무시");
         };
 
-        // 시작 턴이면 바로 UI와 타이머 시작
         if (isMyTurn)
         {
             var myType = UserData.Instance.IsBlack
-                ? Constants.PlayerType.PlayerA
-                : Constants.PlayerType.PlayerB;
-
+                ? Constants.PlayerType.PlayerA : Constants.PlayerType.PlayerB;
             GameManager.Instance.StartTurn(myType);
         }
     }
@@ -111,26 +99,29 @@ public class MultiplayerState : BasePlayerState
         gameLogic.ProcessMarker();
 
         var controller = MatchingManager.Instance?.GetMultiplayController();
-        if (controller != null)
-        {
-            int blockIndex = row * Constants.BlockColumnCount + col;
-            controller.DoPlayerMove(blockIndex);
-        }
+        controller?.DoPlayerMove(row * Constants.BlockColumnCount + col);
 
         gameLogic.blockController.ClearScope();
-        isMyTurn = false; // 착수 후 내 턴 끝
+
+        // 내 착수 후 승리 체크
+        var result = gameLogic.CheckGameResult((row, col));
+        if (result != GameLogic.GameResult.None)
+        {
+            bool iWin = (result == GameLogic.GameResult.Win);
+            gameLogic.EndGame(result);
+            GameManager.Instance.EndGame(iWin);
+            return;
+        }
+
+        isMyTurn = false;
 
         var nextTurn = (playerType == Constants.PlayerType.PlayerA)
-            ? Constants.PlayerType.PlayerB
-            : Constants.PlayerType.PlayerA;
+            ? Constants.PlayerType.PlayerB : Constants.PlayerType.PlayerA;
 
         gameLogic.SetState(
             nextTurn == Constants.PlayerType.PlayerA
-                ? gameLogic.firstPlayerState
-                : gameLogic.secondPlayerState
-        );
+                ? gameLogic.firstPlayerState : gameLogic.secondPlayerState);
 
-        // 턴 전환 후 isMyTurn 동기화
         if (gameLogic.CurrentPlayerState is MultiplayerState multi)
         {
             bool myTurnNow =
@@ -140,12 +131,10 @@ public class MultiplayerState : BasePlayerState
         }
 
         GameManager.Instance.StartTurn(nextTurn);
-
-        Debug.Log("착수 후 턴 전환 " + nextTurn);
     }
 
     protected override void HandleNextTurn(GameLogic gameLogic)
     {
-        Debug.Log("멀티플레이어 상태에서 턴 전환 (GameManager 대신 여기서 처리)");
+        Debug.Log("멀티플레이어 상태에서 턴 전환 처리");
     }
 }


### PR DESCRIPTION
1. 턴 타이머가 game씬에서 코루틴이 종료됐어야 하는데, endgame()이후 main씬으로 넘어오면서 제대로 코루틴이 멈추지 않고 돌고있어서 널레퍼런스 오류가 나와서 TurnTimer()안에 if문으로 조건처리해서 예외처리로 수정

2. 멀티 같은 경우에는 a,b플레이어가 각각 서버에 정보를 전달하다 보니까 
점수가 a컴퓨터에서도 승,패 저장되고 / b컴퓨터에서도 승,패 저장되는게 서버에 날라가서 승리하는 사람은 +2점이 오르고
패배하는 사람은 -2점이 깎이는 현상이 벌어짐
승리하는 사람만 서버에 값을 날리는 식으로 수정함.

3. 승패판정을 CheckGameResult()로 현재 사용하고 있는데 싱글,듀얼 같은 경우는 돌의 위치값을 직접 받으면 돼서 매개변수가 필요없는 형태로 구현이 되어 있는데 멀티 같은 경우는 서버에 값을 전송해서 그걸 받아오는 형태라 매개변수로 위치값을 받아야 해서 오버로딩해서 멀티에서는 매개변수를 받는 함수로 구현